### PR TITLE
Handle rate limits from bsky

### DIFF
--- a/search/hackernews.go
+++ b/search/hackernews.go
@@ -1,70 +1,96 @@
-// search/hackernews.go
 package search
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/charmbracelet/log"
-	"net/http"
-	"time"
+    "encoding/json"
+    "fmt"
+    "github.com/charmbracelet/log"
+    "net/http"
+    "strings"
+    "time"
 )
 
 type HackerNewsSearcher struct{}
 
 func NewHackerNewsSearcher() *HackerNewsSearcher {
-	return &HackerNewsSearcher{}
+    return &HackerNewsSearcher{}
 }
 
 // Platform returns the name of the platform for this searcher.
 func (h *HackerNewsSearcher) Platform() string {
-	return "HackerNews"
+    return "HackerNews"
 }
 
 // Search performs a keyword search on Hacker News after a specified epoch time.
 func (h *HackerNewsSearcher) Search(keyword string, afterEpochSecs int64) ([]SearchResult, error) {
-	apiURL := fmt.Sprintf(
-		"https://hn.algolia.com/api/v1/search_by_date?query=%s&tags=(story,comment)&numericFilters=created_at_i>%d",
-		keyword, afterEpochSecs,
-	)
-	resp, err := http.Get(apiURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
+    apiURL := fmt.Sprintf(
+        "https://hn.algolia.com/api/v1/search_by_date?query=%s&tags=(story,comment)&numericFilters=created_at_i>%d",
+        keyword, afterEpochSecs,
+    )
+    resp, err := http.Get(apiURL)
+    if err != nil {
+        return nil, err
+    }
+    defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %s", resp.Status)
-	}
+    if resp.StatusCode != http.StatusOK {
+        return nil, fmt.Errorf("unexpected status code: %s", resp.Status)
+    }
 
-	var result struct {
-		Hits []struct {
-			Title    string `json:"title"`
-			URL      string `json:"url"`
-			ObjectID string `json:"objectID"`
-		} `json:"hits"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, err
-	}
+    var result struct {
+        Hits []struct {
+            Title       string `json:"title"`
+            URL         string `json:"url"`
+            ObjectID    string `json:"objectID"`
+            CreatedAt   int64  `json:"created_at_i"`
+            CommentText string `json:"comment_text"`
+            StoryTitle  string `json:"story_title"`
+            Type        string `json:"_tags"` // Changed to string
+        } `json:"hits"`
+    }
+    if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+        return nil, err
+    }
 
-	var results []SearchResult
-	timestamp := time.Now().Unix()
-	for _, hit := range result.Hits {
-		if hit.Title == "" || hit.ObjectID == "" {
-			log.Printf("Skipping hit due to missing title or objectID")
-			continue
-		}
+    var results []SearchResult
+    timestamp := time.Now().Unix()
+    for _, hit := range result.Hits {
+        if hit.ObjectID == "" {
+            log.Debug("Skipping hit due to missing objectID")
+            continue
+        }
 
-		// Use the Hacker News post URL rather than the external URL
-		hackerNewsURL := fmt.Sprintf("https://news.ycombinator.com/item?id=%s", hit.ObjectID)
-		results = append(results, SearchResult{
-			Platform:  h.Platform(),
-			Keyword:   keyword,
-			Title:     hit.Title,
-			URL:       hackerNewsURL,
-			Timestamp: timestamp,
-		})
-	}
+        // Build the HN URL
+        hackerNewsURL := fmt.Sprintf("https://news.ycombinator.com/item?id=%s", hit.ObjectID)
 
-	return results, nil
+        // Check if this is a comment
+        isComment := strings.Contains(hit.Type, "comment")
+
+        title := hit.Title
+        content := ""
+
+        if isComment {
+            // For comments, use the story title and comment text
+            if hit.StoryTitle != "" {
+                title = fmt.Sprintf("Comment on: %s", hit.StoryTitle)
+            }
+            content = hit.CommentText
+        }
+
+        // Skip if we couldn't determine a title
+        if title == "" {
+            log.Debug("Skipping hit due to missing title", "objectID", hit.ObjectID)
+            continue
+        }
+
+        results = append(results, SearchResult{
+            Platform:  h.Platform(),
+            Keyword:   keyword,
+            Title:     title,
+            URL:       hackerNewsURL,
+            Content:   content,
+            Timestamp: timestamp,
+        })
+    }
+
+    return results, nil
 }

--- a/search/hackernews.go
+++ b/search/hackernews.go
@@ -1,96 +1,96 @@
 package search
 
 import (
-    "encoding/json"
-    "fmt"
-    "github.com/charmbracelet/log"
-    "net/http"
-    "strings"
-    "time"
+	"encoding/json"
+	"fmt"
+	"github.com/charmbracelet/log"
+	"net/http"
+	"strings"
+	"time"
 )
 
 type HackerNewsSearcher struct{}
 
 func NewHackerNewsSearcher() *HackerNewsSearcher {
-    return &HackerNewsSearcher{}
+	return &HackerNewsSearcher{}
 }
 
 // Platform returns the name of the platform for this searcher.
 func (h *HackerNewsSearcher) Platform() string {
-    return "HackerNews"
+	return "HackerNews"
 }
 
 // Search performs a keyword search on Hacker News after a specified epoch time.
 func (h *HackerNewsSearcher) Search(keyword string, afterEpochSecs int64) ([]SearchResult, error) {
-    apiURL := fmt.Sprintf(
-        "https://hn.algolia.com/api/v1/search_by_date?query=%s&tags=(story,comment)&numericFilters=created_at_i>%d",
-        keyword, afterEpochSecs,
-    )
-    resp, err := http.Get(apiURL)
-    if err != nil {
-        return nil, err
-    }
-    defer resp.Body.Close()
+	apiURL := fmt.Sprintf(
+		"https://hn.algolia.com/api/v1/search_by_date?query=%s&tags=(story,comment)&numericFilters=created_at_i>%d",
+		keyword, afterEpochSecs,
+	)
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
 
-    if resp.StatusCode != http.StatusOK {
-        return nil, fmt.Errorf("unexpected status code: %s", resp.Status)
-    }
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %s", resp.Status)
+	}
 
-    var result struct {
-        Hits []struct {
-            Title       string `json:"title"`
-            URL         string `json:"url"`
-            ObjectID    string `json:"objectID"`
-            CreatedAt   int64  `json:"created_at_i"`
-            CommentText string `json:"comment_text"`
-            StoryTitle  string `json:"story_title"`
-            Type        string `json:"_tags"` // Changed to string
-        } `json:"hits"`
-    }
-    if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-        return nil, err
-    }
+	var result struct {
+		Hits []struct {
+			Title       string `json:"title"`
+			URL         string `json:"url"`
+			ObjectID    string `json:"objectID"`
+			CreatedAt   int64  `json:"created_at_i"`
+			CommentText string `json:"comment_text"`
+			StoryTitle  string `json:"story_title"`
+			Type        string `json:"_tags"` // Changed to string
+		} `json:"hits"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
 
-    var results []SearchResult
-    timestamp := time.Now().Unix()
-    for _, hit := range result.Hits {
-        if hit.ObjectID == "" {
-            log.Debug("Skipping hit due to missing objectID")
-            continue
-        }
+	var results []SearchResult
+	timestamp := time.Now().Unix()
+	for _, hit := range result.Hits {
+		if hit.ObjectID == "" {
+			log.Debug("Skipping hit due to missing objectID")
+			continue
+		}
 
-        // Build the HN URL
-        hackerNewsURL := fmt.Sprintf("https://news.ycombinator.com/item?id=%s", hit.ObjectID)
+		// Build the HN URL
+		hackerNewsURL := fmt.Sprintf("https://news.ycombinator.com/item?id=%s", hit.ObjectID)
 
-        // Check if this is a comment
-        isComment := strings.Contains(hit.Type, "comment")
+		// Check if this is a comment
+		isComment := strings.Contains(hit.Type, "comment")
 
-        title := hit.Title
-        content := ""
+		title := hit.Title
+		content := ""
 
-        if isComment {
-            // For comments, use the story title and comment text
-            if hit.StoryTitle != "" {
-                title = fmt.Sprintf("Comment on: %s", hit.StoryTitle)
-            }
-            content = hit.CommentText
-        }
+		if isComment {
+			// For comments, use the story title and comment text
+			if hit.StoryTitle != "" {
+				title = fmt.Sprintf("Comment on: %s", hit.StoryTitle)
+			}
+			content = hit.CommentText
+		}
 
-        // Skip if we couldn't determine a title
-        if title == "" {
-            log.Debug("Skipping hit due to missing title", "objectID", hit.ObjectID)
-            continue
-        }
+		// Skip if we couldn't determine a title
+		if title == "" {
+			log.Debug("Skipping hit due to missing title", "objectID", hit.ObjectID)
+			continue
+		}
 
-        results = append(results, SearchResult{
-            Platform:  h.Platform(),
-            Keyword:   keyword,
-            Title:     title,
-            URL:       hackerNewsURL,
-            Content:   content,
-            Timestamp: timestamp,
-        })
-    }
+		results = append(results, SearchResult{
+			Platform:  h.Platform(),
+			Keyword:   keyword,
+			Title:     title,
+			URL:       hackerNewsURL,
+			Content:   content,
+			Timestamp: timestamp,
+		})
+	}
 
-    return results, nil
+	return results, nil
 }


### PR DESCRIPTION
- **handle hacker news comments better**
- **handle rate limits**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Handle Bluesky rate limits and improve Hacker News comment handling in `bsky.go` and `hackernews.go`.
> 
>   - **Bluesky Rate Limit Handling**:
>     - In `bsky.go`, handle rate limits by checking for `http.StatusTooManyRequests` and logging a warning with `Retry-After` header.
>     - Return empty results instead of an error for rate limit and other non-200 status codes.
>   - **Hacker News Comment Handling**:
>     - In `hackernews.go`, improve comment handling by using `story_title` and `comment_text` for comments.
>     - Skip hits with missing `objectID` or `title`, logging debug messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Fgrass&utm_source=github&utm_medium=referral)<sup> for 8e94f00aeba549a9e35e0c2ae56a2c57f1e2f7ee. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->